### PR TITLE
inProd early update

### DIFF
--- a/database/dbfuncs.py
+++ b/database/dbfuncs.py
@@ -389,6 +389,12 @@ def addWIPOverrideIntoQueue(cursor, WIP, QTY):
 
     cursor.execute(db_query)
 
+    
+    db_query = f"""UPDATE tblorders SET inprod = False
+    WHERE WIP = {WIP} AND QTY = {QTY} AND inprod = True"""
+
+    cursor.execute(db_query)
+
 """
 ----------------
 UPDATE FUNCTIONS


### PR DESCRIPTION
Change the inProd field to False when an override is detected, instead of when the t-end is updated. This should make inProd a more accurate descriptor of what tags are currently on the production line and which aren't